### PR TITLE
Add additional customizations, and ensure valid tailwind.config.js

### DIFF
--- a/lib/install/tailwind.config.js
+++ b/lib/install/tailwind.config.js
@@ -1,7 +1,7 @@
 const defaultTheme = require('tailwindcss/defaultTheme')
 
 module.exports = {
-  content: <%= Tailwindcss::Engine.globs.to_json %>,
+  content: [], // Configure me using Tailwindcss::Engine.globs
   theme: {
     extend: {
       fontFamily: {

--- a/lib/tailwindcss/commands.rb
+++ b/lib/tailwindcss/commands.rb
@@ -74,7 +74,9 @@ module Tailwindcss
       end
 
       def compile_command(debug: false, **kwargs)
-        tailwind_config_template = ERB.new(File.read(Rails.root.join("config/tailwind.config.js")))
+        tailwind_config_contents = File.read(Rails.root.join("config/tailwind.config.js"))
+        tailwind_config_contents.gsub!(/content:\s*(\[[\s\S]*?\]|\{[\s\S]*?}|\([^)]*\))/,'content: <%= Tailwindcss::Engine.globs.to_json %>')
+        tailwind_config_template = ERB.new(tailwind_config_contents)
         tailwind_config = Tempfile.new("tailwind-config").tap do |f|
           f.write(tailwind_config_template.result)
           if debug

--- a/lib/tailwindcss/commands.rb
+++ b/lib/tailwindcss/commands.rb
@@ -75,23 +75,30 @@ module Tailwindcss
 
       def compile_command(debug: false, **kwargs)
         tailwind_config_contents = File.read(Rails.root.join("config/tailwind.config.js"))
-        tailwind_config_contents.gsub!(/content:\s*(\[[\s\S]*?\]|\{[\s\S]*?}|\([^)]*\))/,'content: <%= Tailwindcss::Engine.globs.to_json %>')
-        tailwind_config_template = ERB.new(tailwind_config_contents)
-        tailwind_config = Tempfile.new("tailwind-config").tap do |f|
-          f.write(tailwind_config_template.result)
-          if debug
-            f.rewind
-            puts "config:"
-            puts f.read
-          end
-          f.close
-        end
+        config_path = if tailwind_config_contents.include?('content: []')
+                        tailwind_config_contents.gsub!('content: []','content: <%= Tailwindcss::Engine.globs.to_json %>')
+
+                        tailwind_config_template = ERB.new(tailwind_config_contents)
+                        tailwind_config = Tempfile.new("tailwind-config").tap do |f|
+                          f.write(tailwind_config_template.result)
+                          if debug
+                            f.rewind
+                            puts "config:"
+                            puts f.read
+                          end
+                          f.close
+                        end
+                        tailwind_config.path
+                      else
+                        puts "WARNING: not empty content config found in config/tailwind.config.js, keeping it as-is"
+                        Rails.root.join("config/tailwind.config.js").to_s
+                      end
 
         command = [
           executable(**kwargs),
           "-i", Rails.root.join("app/assets/stylesheets/application.tailwind.css").to_s,
           "-o", Rails.root.join("app/assets/builds/tailwind.css").to_s,
-          "-c", tailwind_config.path,
+          "-c", config_path,
         ]
 
         command << "--minify" unless (debug || rails_css_compressor?)

--- a/lib/tailwindcss/engine.rb
+++ b/lib/tailwindcss/engine.rb
@@ -4,20 +4,17 @@ module Tailwindcss
   class Engine < ::Rails::Engine
     class << self
       def globs
-        Rails.application.config.assets.tailwind_paths.flat_map do |path|
-          [
-            "#{path}/public/*.html",
-            "#{path}/app/helpers/**/*.rb",
-            "#{path}/app/javascript/**/*.js",
-            "#{path}/app/views/**/*.{erb,haml,html,slim}",
-          ]
-        end
+        Rails.application.config.assets.tailwind_roots.flat_map do |path|
+          Rails.application.config.assets.tailwind_source_paths.map { |source| "#{path}/#{source}" }
+        end + Rails.application.config.assets.tailwind_custom_paths
       end
     end
 
     initializer "tailwindcss.assets" do
       Rails.application.config.assets.precompile += %w( inter-font.css )
-      Rails.application.config.assets.tailwind_paths = [Rails.root]
+      Rails.application.config.assets.tailwind_source_paths = %w( public/*.html app/helpers/**/*.rb app/javascript/**/*.js app/views/**/*.{erb,haml,html,slim} )
+      Rails.application.config.assets.tailwind_roots = [Rails.root]
+      Rails.application.config.assets.tailwind_custom_paths = []
     end
 
     initializer "tailwindcss.disable_generator_stylesheets" do


### PR DESCRIPTION
This PR adds additional configuration options to implementation:

- `tailwind_source_paths` &mdash; allows usage with custom content layout, without manually redefining all paths. Useful for cases of multi-project/engine with custom content layout.
- `tailwind_custom_paths` &mdash; allows usage of non-standard paths to the content path.

It also ensures that we keep tailwind.config.js as a valid JS file, that may be fed to the manual tailwind processing (for cases like [raw content processing](https://tailwindcss.com/docs/content-configuration#configuring-raw-content)) and enforces user to move custom content config from js config to application config.